### PR TITLE
Fix Windows compatibility issues in Mosaic onboarding

### DIFF
--- a/src/mosaic/geometry.py
+++ b/src/mosaic/geometry.py
@@ -171,12 +171,15 @@ class GeometryData:
 
     def set_faces(self, faces):
         """Set triangular face connectivity on the polydata."""
-        faces = np.asarray(faces, dtype=int)
+        # Use int64 explicitly because numpy_to_vtkIdTypeArray() requires int64 input.
+        # dtype=int is platform-dependent (int32 on Windows, typically int64 on
+        # Linux/macOS), which can otherwise cause a ValueError.
+        faces = np.asarray(faces, dtype=np.int64)
         if faces.ndim == 2 and faces.shape[1] == 3:
             faces = np.concatenate(
                 (np.full((faces.shape[0], 1), fill_value=3), faces),
                 axis=1,
-                dtype=int,
+                dtype=np.int64,
             )
         poly_cells = vtkCellArray()
         poly_cells.SetCells(

--- a/src/mosaic/stylesheets.py
+++ b/src/mosaic/stylesheets.py
@@ -168,7 +168,11 @@ Colors.apply_palette(Colors.LIGHT)
 
 def _get_resource_path(resource_name):
     """Get the absolute path to a resource in the package."""
-    return str(files("mosaic.data").joinpath(f"data/{resource_name}"))
+    # Build an absolute path to the requested resource inside the package data directory.
+    # Convert the path to POSIX format because Qt stylesheets expect forward slashes.
+    # On Windows, backslashes may be misinterpreted as escape characters in Qt's QSS parser,
+    # so using POSIX-style paths ensures consistent behavior across platforms.
+    return (files("mosaic.data") / "data" / resource_name).as_posix()
 
 
 def _build_QGroupBox_style():
@@ -939,7 +943,7 @@ def build_appstyle():
                 # "QWidgetWindow ... must be a top level window" warnings.
                 menu = QMenu(combo.window() or combo)
                 menu.setStyleSheet(
-                    "QMenu { padding: 0px 0px; }" "QMenu::item { padding: 4px 7px; }"
+                    "QMenu { padding: 0px 0px; }QMenu::item { padding: 4px 7px; }"
                 )
                 menu.setWindowFlags(
                     menu.windowFlags()

--- a/src/mosaic/stylesheets.py
+++ b/src/mosaic/stylesheets.py
@@ -943,7 +943,7 @@ def build_appstyle():
                 # "QWidgetWindow ... must be a top level window" warnings.
                 menu = QMenu(combo.window() or combo)
                 menu.setStyleSheet(
-                    "QMenu { padding: 0px 0px; }QMenu::item { padding: 4px 7px; }"
+                    "QMenu { padding: 0px 0px; }" "QMenu::item { padding: 4px 7px; }"
                 )
                 menu.setWindowFlags(
                     menu.windowFlags()


### PR DESCRIPTION
Hi @maurerv,

First of all, I want to say that Mosaic looks great, and I really appreciate the time and effort that has gone into making it accessible to others.

Together with [this PR](KosinskiLab/pyTME#25) in `pyTME`, the two fixes in this PR allow me to open Mosaic on Windows and complete the `--onboard basics` walkthrough without errors.

This PR contains two fixes:

1. **Normalize resource paths to POSIX format**

   On Windows, resource paths are typically represented with backslashes, for example:

   ```text
   path\to\resources\resource.svg
   ```

   However, when such paths are later embedded in strings:

   https://github.com/KosinskiLab/mosaic/blob/6684fe875eabec1888a1f43f00d8cd442c1614da/src/mosaic/stylesheets.py#L277-L286

   The backslashes can be interpreted as escape characters, which may break the resource path depending on the specific characters.

   By converting the path to POSIX format before returning it, we ensure it uses forward slashes instead, preventing escape-related issues.

2. **Ensure `faces` uses `int64` before passing to VTK**

   `numpy_to_vtkIdTypeArray()` expects an array of type `int64`. On `main`, I currently encounter the following error:

   ```text
   File "C:\Users\boydpeters\projects\mosaic\src\mosaic\parallel.py", line 728, in _check_completed_tasks
     task_info["callback"](result)
   File "C:\Users\boydpeters\projects\mosaic\src\mosaic\tabs\model.py", line 326, in _default_callback
     new_geom.change_representation("surface")
   File "C:\Users\boydpeters\projects\mosaic\src\mosaic\geometry.py", line 1276, in change_representation
     self._set_faces(mesh.triangles)
   File "C:\Users\boydpeters\projects\mosaic\src\mosaic\geometry.py", line 753, in _set_faces
     self._geometry_data.set_faces(faces)
   File "C:\Users\boydpeters\projects\mosaic\src\mosaic\geometry.py", line 184, in set_faces
     numpy_support.numpy_to_vtkIdTypeArray(faces.ravel()),
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "C:\Users\boydpeters\projects\mosaic\.venv\Lib\site-packages\vtkmodules\util\numpy_support.py", line 199, in numpy_to_vtkIdTypeArray
     raise ValueError(
   ValueError: Expecting a numpy.int64 array, got int32 instead.
   ```

   The array is currently created as:

   ```python
   faces = np.asarray(faces, dtype=int)
   ```

   The issue is that NumPy’s `int` maps to platform-dependent integer sizes:

   * On Linux/macOS, it typically resolves to `int64`
   * On Windows, it typically resolves to `int32`

   This difference exists because the underlying C `long` type is defined differently across platforms. So by setting the dtype to `np.int64`, we ensure that its the correct dtype on all platforms.

With these two changes, together with the `pyTME` PR, the onboarding flow runs successfully on Windows.

I’m aware that some dependencies (for example, `pyfreedts`) currently do not build on Windows, so full support is still limited. However, this would at least allow users to load `.mrc` files, potentially run `pyfreedts` on an HPC system, and then inspect the resulting meshes in Mosaic again.

That said, if Windows support is considered out of scope for the project, that is entirely reasonable.

Alternatively, feel free to take the ideas from this PR and adapt them in whatever way fits best.
